### PR TITLE
Upped react-native-background-geolocation Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/react-native-geolocation",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Basic geolocation + geofencing. Delegates to react-native-background-geolocation for iOS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updated to fix issues I'm getting in Xcode 10.2.

`no type or protocol named 'RCTInvalidating'`
`reference to 'RCTInvalidating' is ambiguous`