### PR TITLE
Add `accuracy` to `getCurrentPosition` response

### DIFF
--- a/android/src/main/java/co/uk/hive/reactnativegeolocation/RNMapper.java
+++ b/android/src/main/java/co/uk/hive/reactnativegeolocation/RNMapper.java
@@ -30,6 +30,7 @@ public class RNMapper {
         WritableMap coords = Arguments.createMap();
         coords.putDouble("latitude", location.getLatitude());
         coords.putDouble("longitude", location.getLongitude());
+        coords.putDouble("accuracy", location.getAccuracyInMeters());
         WritableMap result = Arguments.createMap();
         result.putMap("coords", coords);
         return result;

--- a/android/src/main/java/co/uk/hive/reactnativegeolocation/location/LatLng.java
+++ b/android/src/main/java/co/uk/hive/reactnativegeolocation/location/LatLng.java
@@ -3,10 +3,12 @@ package co.uk.hive.reactnativegeolocation.location;
 public class LatLng {
     private final double latitude;
     private final double longitude;
+    private final double accuracyInMeters;
 
-    public LatLng(double latitude, double longitude) {
+    public LatLng(double latitude, double longitude, double accuracyInMeters) {
         this.latitude = latitude;
         this.longitude = longitude;
+        this.accuracyInMeters = accuracyInMeters;
     }
 
     public double getLatitude() {
@@ -15,5 +17,9 @@ public class LatLng {
 
     public double getLongitude() {
         return longitude;
+    }
+
+    public double getAccuracyInMeters() {
+        return accuracyInMeters;
     }
 }

--- a/android/src/main/java/co/uk/hive/reactnativegeolocation/location/LocationController.java
+++ b/android/src/main/java/co/uk/hive/reactnativegeolocation/location/LocationController.java
@@ -82,7 +82,9 @@ public class LocationController {
                 if (locationResult.getLastLocation() != null) {
                     singleLocationCallback.locationReceived(new LatLng(
                             locationResult.getLastLocation().getLatitude(),
-                            locationResult.getLastLocation().getLongitude()));
+                            locationResult.getLastLocation().getLongitude(),
+                            locationResult.getLastLocation().getAccuracy()
+                    ));
                 } else {
                     singleLocationCallback.locationUnknown();
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/react-native-geolocation",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Basic geolocation + geofencing. Delegates to react-native-background-geolocation for iOS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The `react-native-background-geolocation` returns values other that `latitude` & `longitude` - the only 2 our custom implementation responds with. One of these is `accuracy`. 

We plan to use `accuracy` in `android-home-presence` to help set more appropriate radius; a radius smaller than accuracy will not trigger.