### PR TITLE
Fixed delegate setting upon initialization

### DIFF
--- a/ios/RNGeolocation/RNHiveGeolocationManager.swift
+++ b/ios/RNGeolocation/RNHiveGeolocationManager.swift
@@ -39,6 +39,11 @@ class RNHiveGeolocationManager: NSObject {
     private var geofenceRequestCompletion: RNHiveGeofenceRequestCompletion? = nil
     private var geofenceEventResponder: RNHiveGeofenceEventResponder? = nil
     
+    override init() {
+        super.init()
+        self.locationManager.delegate = self
+    }
+    
     @objc public func allGeofences() -> [RNHiveGeofence]  {
         guard let savedData = UserDefaults.standard.data(forKey: savedGeofencesKey) else { return [] }
         let decoder = JSONDecoder()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/react-native-geolocation",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Basic geolocation + geofencing. Delegates to react-native-background-geolocation for iOS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Setting up delegate upon the init() call to make sure we get calls from OS when the app is awakened by the OS in the background