### PR TITLE
APPS-1585 Removed array of stored events to guarantee there is a single one

### DIFF
--- a/ios/RNGeolocation/RNHiveGeolocationManager.swift
+++ b/ios/RNGeolocation/RNHiveGeolocationManager.swift
@@ -75,7 +75,7 @@ public class RNHiveGeolocationManager: NSObject {
      serves as a workaround to store a single event that triggered app to start in the background,
      so that it can be retrieved later after JS finishes it's procedures.
      */
-    private var storedGeofenceNotifications: [RNHiveGeofenceEvent] = []
+    private var pendingGeofenceNotification: RNHiveGeofenceEvent? = nil
     
     private var geofenceRequestCompletion: RNHiveGeofenceRequestCompletion? = nil
     private var geofenceEventResponder: RNHiveGeofenceEventResponder? = nil
@@ -200,13 +200,12 @@ public class RNHiveGeolocationManager: NSObject {
     }
     
     @objc public func triggerStoredEvents() {
-        for event in storedGeofenceNotifications {
-            if let responder = geofenceEventResponder {
-                print("triggering stored geofence: \(event)")
-                responder(event, nil)
-            }
+        guard let pendingNotification = pendingGeofenceNotification,
+            let responder = geofenceEventResponder else {
+                return
         }
-        storedGeofenceNotifications.removeAll()
+        responder(pendingNotification, nil)
+        pendingGeofenceNotification = nil
     }
     
     @objc public func stopMonitoringGeofences(_ completion: RNHiveGeofenceRequestCompletion?) {
@@ -334,11 +333,7 @@ public class RNHiveGeolocationManager: NSObject {
     }
     
     private func saveGeofenceEventNotification(event: RNHiveGeofenceEvent) {
-        if !storedGeofenceNotifications.contains(where: { (geofenceEvent) -> Bool in
-            return geofenceEvent == event
-        }) {
-            storedGeofenceNotifications.append(event)
-        }
+        pendingGeofenceNotification = event
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/react-native-geolocation",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "homepage": "https://github.com/ConnectedHomes/react-native-geolocation",
   "description": "Basic geolocation + geofencing. Delegates to react-native-background-geolocation for iOS.",
   "main": "index.js",


### PR DESCRIPTION
For some reason we're a number of notifications that trigger app start in the background. to guarantee it's a single one array is removed and added a variable to store it. This is the edge case where this notification should ideally always be one. It should not influence the flow