### PR TITLE
MA1-3631: Geolocation not working on Android

### DIFF
--- a/android/src/main/java/co/uk/hive/reactnativegeolocation/location/LocationError.java
+++ b/android/src/main/java/co/uk/hive/reactnativegeolocation/location/LocationError.java
@@ -7,4 +7,9 @@ package co.uk.hive.reactnativegeolocation.location;
 class LocationError {
     static final int LOCATION_UNKNOWN = 0;
     static final int PERMISSION_DENIED = 1;
+    static final int LOCATION_CLIENT_IS_NULL = 3;
+    static final int LOCATION_DISABLED = 4;
+    static final int LOCATION_IS_NULL = 5;
+    static final int CURRENT_LOCATION_FAILED = 6;
+    static final int LOCATION_SETTINGS_FAILED = 7;
 }

--- a/index.js
+++ b/index.js
@@ -11,12 +11,24 @@ const LocationError = {
   LOCATION_UNKNOWN: 0,
   PERMISSION_DENIED: 1,
   NETWORK_ERROR: 2,
+  LOCATION_CLIENT_IS_NULL: 3,
+  LOCATION_DISABLED: 4,
+  LOCATION_IS_NULL: 5,
+  CURRENT_LOCATION_FAILED: 6,
+  LOCATION_SETTINGS_FAILED: 7,
   LOCATION_TIMEOUT: 408,
 };
 
 export default class Geolocation extends PlatformGeolocation {
   static isLocationUnknown(error) {
-      return error === LocationError.LOCATION_UNKNOWN;
+      return [
+        LocationError.PERMISSION_DENIED,
+        LocationError.LOCATION_CLIENT_IS_NULL ,
+        LocationError.LOCATION_DISABLED ,
+        LocationError.LOCATION_IS_NULL ,
+        LocationError.CURRENT_LOCATION_FAILED ,
+        LocationError.LOCATION_SETTINGS_FAILED ,
+      ].includes(error);
   }
   
   static isPermissionDenied(error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connected-home/react-native-geolocation",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "homepage": "https://github.com/ConnectedHomes/react-native-geolocation",
   "description": "Basic geolocation + geofencing. Delegates to react-native-background-geolocation for iOS.",
   "main": "index.js",


### PR DESCRIPTION
### Description of the issue

We have had some reports of Geolocation not working with Android devices. IOS known to be working as expected as one affected customer tested on an IOS device and notifications were sent.

### Analysis

I could not reproduce the issue on Pixel 5 (Android 13). The error message could be triggered in several different ways.
The most probable is when RN tries to fetch position via native `getPosition` method.

### Solution to the issue

Add different error code for every possible code path of failure.

### Link to Jira ticket

[comment]: # 'The ticket number is automatically linked if the repo autolinks are setup'

MA1-3631
